### PR TITLE
fix: add events.md

### DIFF
--- a/TOC/events.md
+++ b/TOC/events.md
@@ -1,0 +1,16 @@
+# CI/CD Events
+
+- [Continuous Delivery Summit](https://events.linuxfoundation.org/continuous-delivery-summit/)
+
+# KubeCon and CNCF Events
+
+- [KubeCon + CloudNativeCon North America](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/)
+- [GitOpsCon North America](https://events.linuxfoundation.org/gitopscon-north-america/)
+
+# Open Source Summit
+
+- [ContainerCon Europe](https://events.linuxfoundation.org/open-source-summit-europe/about/containercon/)
+- [Open Source Summit Europe](https://events.linuxfoundation.org/open-source-summit-europe/about/containercon/)
+- [OpenSSF Day Europe](https://events.linuxfoundation.org/open-source-summit-europe/)
+- [SupplyChainSecurityCon Europe](https://events.linuxfoundation.org/open-source-summit-europe/about/supplychainsecuritycon/)
+- [CloudOpen Japan](https://events.linuxfoundation.org/open-source-summit-japan/about/cloudopen/)


### PR DESCRIPTION
This list contains Linux Foundation events in 2022.