### PR TITLE
fix: remove the jameses

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,5 +5,3 @@ aliases:
   - tomhobson
   - msvticket
   - garethjevans
-  - rawlingsj
-  - jstrachan


### PR DESCRIPTION
There is a problem now that lighthouse often suggests developers to assign one of the jameses. The problem is that none of them responds. So I say we remove them from here. If they get active again we can easily add them again.